### PR TITLE
minor bugfixes

### DIFF
--- a/source/entity.js
+++ b/source/entity.js
@@ -192,7 +192,7 @@ class entity_t {
 
 	_spawn_particles(amount, speed = 1, model, texture, lifetime) {
 		for (let i = 0; i < amount; i++) {
-			let particle = game_spawn(entity_particle_t, this.p);
+			let particle = game_spawn(entity_particle_t, vec3_clone(this.p));
 			particle._model = model;
 			particle._texture = texture;
 			particle._die_at = game_time + lifetime + Math.random() * lifetime * 0.2;

--- a/source/renderer.js
+++ b/source/renderer.js
@@ -116,7 +116,7 @@ R_SOURCE_FS =
 		// 'gl_FragColor=vec4(1.0,1.0,1.0,1.0);' + 
 
 		// Calculate all lights
-		'vec3 vl;' +
+		'vec3 vl=vec3(0,0,0);' +
 		'for(int i=0;i<'+R_MAX_LIGHT_V3+';i+=2) {' +
 			'vl+=' +
 				// Angle to normal


### PR DESCRIPTION
1. If copying the glsl to a desktop environment, `vec3 vl;` is uninitialized, drawing whatever's in vram.
2. Particles are spawned sharing a reference to the spawner's position.